### PR TITLE
Add support for additional testnets (Rinkeby and Görli)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Running the following commands will start a Docker container in
 a data directory at `<working directory>/ethereum-data` and the Rosetta API accessible
 at port `8080`.
 
+The `NETWORK` environment variable can be set to `MAINNET`, `ROPSTEN`, `RINKEBY`, `GOERLI` or `TESTNET` (which defaults to `ROPSTEN`).
+
 _It is possible to run `rosetta-ethereum` using a remote node by adding
 `-e "GETH=<node url>"` to any online command._
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -42,11 +42,14 @@ const (
 	// Mainnet is the Ethereum Mainnet.
 	Mainnet string = "MAINNET"
 
-	// Ropsten is the Ethereum Ropsten network.
+	// Ropsten is the Ethereum Ropsten testnet.
 	Ropsten string = "ROPSTEN"
 
-	// Rinkeby is the Ethereum Rinkeby network.
+	// Rinkeby is the Ethereum Rinkeby testnet.
 	Rinkeby string = "RINKEBY"
+
+	// Goerli is the Ethereum Görli testnet.
+	Goerli string = "GOERLI"
 
 	// Testnet defaults to `Ropsten` for backwards compatibility.
 	Testnet string = "TESTNET"
@@ -139,6 +142,14 @@ func LoadConfiguration() (*Configuration, error) {
 		config.GenesisBlockIdentifier = ethereum.RinkebyGenesisBlockIdentifier
 		config.Params = params.RinkebyChainConfig
 		config.GethArguments = ethereum.RinkebyGethArguments
+	case Goerli:
+		config.Network = &types.NetworkIdentifier{
+			Blockchain: ethereum.Blockchain,
+			Network:    ethereum.GoerliNetwork,
+		}
+		config.GenesisBlockIdentifier = ethereum.GoerliGenesisBlockIdentifier
+		config.Params = params.GoerliChainConfig
+		config.GethArguments = ethereum.GoerliGethArguments
 	case "":
 		return nil, errors.New("NETWORK must be populated")
 	default:

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -39,10 +39,13 @@ const (
 	// to make outbound connections.
 	Offline Mode = "OFFLINE"
 
-	// Mainnet is the Bitcoin Mainnet.
+	// Mainnet is the Ethereum Mainnet.
 	Mainnet string = "MAINNET"
 
-	// Testnet is Bitcoin Testnet3.
+	// Ropsten is the Ethereum Ropsten network.
+	Ropsten string = "ROPSTEN"
+
+	// Testnet defaults to `Ropsten` for backwards compatibility.
 	Testnet string = "TESTNET"
 
 	// DataDirectory is the default location for all
@@ -117,14 +120,14 @@ func LoadConfiguration() (*Configuration, error) {
 		config.GenesisBlockIdentifier = ethereum.MainnetGenesisBlockIdentifier
 		config.Params = params.MainnetChainConfig
 		config.GethArguments = ethereum.MainnetGethArguments
-	case Testnet:
+	case Testnet, Ropsten:
 		config.Network = &types.NetworkIdentifier{
 			Blockchain: ethereum.Blockchain,
-			Network:    ethereum.TestnetNetwork,
+			Network:    ethereum.RopstenNetwork,
 		}
-		config.GenesisBlockIdentifier = ethereum.TestnetGenesisBlockIdentifier
+		config.GenesisBlockIdentifier = ethereum.RopstenGenesisBlockIdentifier
 		config.Params = params.RopstenChainConfig
-		config.GethArguments = ethereum.TestnetGethArguments
+		config.GethArguments = ethereum.RopstenGethArguments
 	case "":
 		return nil, errors.New("NETWORK must be populated")
 	default:

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -45,6 +45,9 @@ const (
 	// Ropsten is the Ethereum Ropsten network.
 	Ropsten string = "ROPSTEN"
 
+	// Rinkeby is the Ethereum Rinkeby network.
+	Rinkeby string = "RINKEBY"
+
 	// Testnet defaults to `Ropsten` for backwards compatibility.
 	Testnet string = "TESTNET"
 
@@ -128,6 +131,14 @@ func LoadConfiguration() (*Configuration, error) {
 		config.GenesisBlockIdentifier = ethereum.RopstenGenesisBlockIdentifier
 		config.Params = params.RopstenChainConfig
 		config.GethArguments = ethereum.RopstenGethArguments
+	case Rinkeby:
+		config.Network = &types.NetworkIdentifier{
+			Blockchain: ethereum.Blockchain,
+			Network:    ethereum.RinkebyNetwork,
+		}
+		config.GenesisBlockIdentifier = ethereum.RinkebyGenesisBlockIdentifier
+		config.Params = params.RinkebyChainConfig
+		config.GethArguments = ethereum.RinkebyGethArguments
 	case "":
 		return nil, errors.New("NETWORK must be populated")
 	default:

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -84,6 +84,23 @@ func TestLoadConfiguration(t *testing.T) {
 				GethArguments:          ethereum.MainnetGethArguments,
 			},
 		},
+		"all set (ropsten)": {
+			Mode:    string(Online),
+			Network: Ropsten,
+			Port:    "1000",
+			cfg: &Configuration{
+				Mode: Online,
+				Network: &types.NetworkIdentifier{
+					Network:    ethereum.RopstenNetwork,
+					Blockchain: ethereum.Blockchain,
+				},
+				Params:                 params.RopstenChainConfig,
+				GenesisBlockIdentifier: ethereum.RopstenGenesisBlockIdentifier,
+				Port:                   1000,
+				GethURL:                DefaultGethURL,
+				GethArguments:          ethereum.RopstenGethArguments,
+			},
+		},
 		"all set (testnet)": {
 			Mode:    string(Online),
 			Network: Testnet,
@@ -91,19 +108,19 @@ func TestLoadConfiguration(t *testing.T) {
 			cfg: &Configuration{
 				Mode: Online,
 				Network: &types.NetworkIdentifier{
-					Network:    ethereum.TestnetNetwork,
+					Network:    ethereum.RopstenNetwork,
 					Blockchain: ethereum.Blockchain,
 				},
 				Params:                 params.RopstenChainConfig,
-				GenesisBlockIdentifier: ethereum.TestnetGenesisBlockIdentifier,
+				GenesisBlockIdentifier: ethereum.RopstenGenesisBlockIdentifier,
 				Port:                   1000,
 				GethURL:                DefaultGethURL,
-				GethArguments:          ethereum.TestnetGethArguments,
+				GethArguments:          ethereum.RopstenGethArguments,
 			},
 		},
 		"invalid mode": {
 			Mode:    "bad mode",
-			Network: Testnet,
+			Network: Ropsten,
 			Port:    "1000",
 			err:     errors.New("bad mode is not a valid mode"),
 		},
@@ -115,7 +132,7 @@ func TestLoadConfiguration(t *testing.T) {
 		},
 		"invalid port": {
 			Mode:    string(Offline),
-			Network: Testnet,
+			Network: Ropsten,
 			Port:    "bad port",
 			err:     errors.New("unable to parse port bad port"),
 		},

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -118,6 +118,23 @@ func TestLoadConfiguration(t *testing.T) {
 				GethArguments:          ethereum.RinkebyGethArguments,
 			},
 		},
+		"all set (goerli)": {
+			Mode:    string(Online),
+			Network: Goerli,
+			Port:    "1000",
+			cfg: &Configuration{
+				Mode: Online,
+				Network: &types.NetworkIdentifier{
+					Network:    ethereum.GoerliNetwork,
+					Blockchain: ethereum.Blockchain,
+				},
+				Params:                 params.GoerliChainConfig,
+				GenesisBlockIdentifier: ethereum.GoerliGenesisBlockIdentifier,
+				Port:                   1000,
+				GethURL:                DefaultGethURL,
+				GethArguments:          ethereum.GoerliGethArguments,
+			},
+		},
 		"all set (testnet)": {
 			Mode:    string(Online),
 			Network: Testnet,

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -101,6 +101,23 @@ func TestLoadConfiguration(t *testing.T) {
 				GethArguments:          ethereum.RopstenGethArguments,
 			},
 		},
+		"all set (rinkeby)": {
+			Mode:    string(Online),
+			Network: Rinkeby,
+			Port:    "1000",
+			cfg: &Configuration{
+				Mode: Online,
+				Network: &types.NetworkIdentifier{
+					Network:    ethereum.RinkebyNetwork,
+					Blockchain: ethereum.Blockchain,
+				},
+				Params:                 params.RinkebyChainConfig,
+				GenesisBlockIdentifier: ethereum.RinkebyGenesisBlockIdentifier,
+				Port:                   1000,
+				GethURL:                DefaultGethURL,
+				GethArguments:          ethereum.RinkebyGethArguments,
+			},
+		},
 		"all set (testnet)": {
 			Mode:    string(Online),
 			Network: Testnet,

--- a/ethereum/types.go
+++ b/ethereum/types.go
@@ -38,6 +38,10 @@ const (
 	// in RopstenNetworkIdentifier.
 	RopstenNetwork string = "Ropsten"
 
+	// RinkebyNetwork is the value of the network
+	// in RinkebyNetworkNetworkIdentifier.
+	RinkebyNetwork string = "RinkebyNetwork"
+
 	// Symbol is the symbol value
 	// used in Currency.
 	Symbol = "ETH"
@@ -122,6 +126,9 @@ var (
 	// RopstenGethArguments are the arguments to start a ropsten geth instance.
 	RopstenGethArguments = fmt.Sprintf("%s --ropsten", MainnetGethArguments)
 
+	// RinkebyGethArguments are the arguments to start a rinkeby geth instance.
+	RinkebyGethArguments = fmt.Sprintf("%s --rinkeby", MainnetGethArguments)
+
 	// MainnetGenesisBlockIdentifier is the *types.BlockIdentifier
 	// of the mainnet genesis block.
 	MainnetGenesisBlockIdentifier = &types.BlockIdentifier{
@@ -133,6 +140,13 @@ var (
 	// of the Ropsten genesis block.
 	RopstenGenesisBlockIdentifier = &types.BlockIdentifier{
 		Hash:  params.RopstenGenesisHash.Hex(),
+		Index: GenesisBlockIndex,
+	}
+
+	// RinkebyGenesisBlockIdentifier is the *types.BlockIdentifier
+	// of the Ropsten genesis block.
+	RinkebyGenesisBlockIdentifier = &types.BlockIdentifier{
+		Hash:  params.RinkebyGenesisHash.Hex(),
 		Index: GenesisBlockIndex,
 	}
 

--- a/ethereum/types.go
+++ b/ethereum/types.go
@@ -42,6 +42,10 @@ const (
 	// in RinkebyNetworkNetworkIdentifier.
 	RinkebyNetwork string = "RinkebyNetwork"
 
+	// GoerliNetwork is the value of the network
+	// in GoerliNetworkNetworkIdentifier.
+	GoerliNetwork string = "GoerliNetwork"
+
 	// Symbol is the symbol value
 	// used in Currency.
 	Symbol = "ETH"
@@ -129,6 +133,9 @@ var (
 	// RinkebyGethArguments are the arguments to start a rinkeby geth instance.
 	RinkebyGethArguments = fmt.Sprintf("%s --rinkeby", MainnetGethArguments)
 
+	// GoerliGethArguments are the arguments to start a ropsten geth instance.
+	GoerliGethArguments = fmt.Sprintf("%s --goerli", MainnetGethArguments)
+
 	// MainnetGenesisBlockIdentifier is the *types.BlockIdentifier
 	// of the mainnet genesis block.
 	MainnetGenesisBlockIdentifier = &types.BlockIdentifier{
@@ -147,6 +154,13 @@ var (
 	// of the Ropsten genesis block.
 	RinkebyGenesisBlockIdentifier = &types.BlockIdentifier{
 		Hash:  params.RinkebyGenesisHash.Hex(),
+		Index: GenesisBlockIndex,
+	}
+
+	// GoerliGenesisBlockIdentifier is the *types.BlockIdentifier
+	// of the Goerli genesis block.
+	GoerliGenesisBlockIdentifier = &types.BlockIdentifier{
+		Hash:  params.GoerliGenesisHash.Hex(),
 		Index: GenesisBlockIndex,
 	}
 

--- a/ethereum/types.go
+++ b/ethereum/types.go
@@ -34,9 +34,9 @@ const (
 	// in MainnetNetworkIdentifier.
 	MainnetNetwork string = "Mainnet"
 
-	// TestnetNetwork is the value of the network
-	// in TestnetNetworkIdentifier.
-	TestnetNetwork string = "Ropsten"
+	// RopstenNetwork is the value of the network
+	// in RopstenNetworkIdentifier.
+	RopstenNetwork string = "Ropsten"
 
 	// Symbol is the symbol value
 	// used in Currency.
@@ -119,8 +119,8 @@ const (
 )
 
 var (
-	// TestnetGethArguments are the arguments to start a ropsten geth instance.
-	TestnetGethArguments = fmt.Sprintf("%s --ropsten", MainnetGethArguments)
+	// RopstenGethArguments are the arguments to start a ropsten geth instance.
+	RopstenGethArguments = fmt.Sprintf("%s --ropsten", MainnetGethArguments)
 
 	// MainnetGenesisBlockIdentifier is the *types.BlockIdentifier
 	// of the mainnet genesis block.
@@ -129,9 +129,9 @@ var (
 		Index: GenesisBlockIndex,
 	}
 
-	// TestnetGenesisBlockIdentifier is the *types.BlockIdentifier
-	// of the testnet genesis block.
-	TestnetGenesisBlockIdentifier = &types.BlockIdentifier{
+	// RopstenGenesisBlockIdentifier is the *types.BlockIdentifier
+	// of the Ropsten genesis block.
+	RopstenGenesisBlockIdentifier = &types.BlockIdentifier{
 		Hash:  params.RopstenGenesisHash.Hex(),
 		Index: GenesisBlockIndex,
 	}

--- a/services/construction_service_test.go
+++ b/services/construction_service_test.go
@@ -52,7 +52,7 @@ func forceMarshalMap(t *testing.T, i interface{}) map[string]interface{} {
 
 func TestConstructionService(t *testing.T) {
 	networkIdentifier = &types.NetworkIdentifier{
-		Network:    ethereum.TestnetNetwork,
+		Network:    ethereum.RopstenNetwork,
 		Blockchain: ethereum.Blockchain,
 	}
 


### PR DESCRIPTION
### Motivation

Ethereum does not have 1 de-facto testnet. There are in fact several such as `Ropsten`, `Rinkeby`, `Görli` etc. Each network has its own purpose and often developers must test on different networks for a variety of reasons such as where dApps are deployed to.

This PR adds support for additional networks (Rinkeby and Görli), while maintaining backwards compatibility by defaulting `NETWORK=TESTNET` to `Ropsten` which is how it currently behaves.

### Solution

- Refactor the naming of `Testnet...` structs to `Ropsten...` to be clear which network configuration it points to.
- Provide backwards compatibility support by defaulting `TESTNET` to `ROPSTEN` configuration
- Add additional configurations for `Rinkeby` and `Goerli` (Görli)

### Open questions

None