### PR TITLE
Update CA Certificates - x509 error when using remote nodes on Alchemy, QuikNode etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ RUN mv src/rosetta-ethereum /app/rosetta-ethereum \
 ## Build Final Image
 FROM ubuntu:18.04
 
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
 RUN mkdir -p /app \
   && chown -R nobody:nogroup /app \
   && mkdir -p /data \


### PR DESCRIPTION
### Motivation

The Certificate Authority certificates in the `Docker` Ubuntu build are not up-to-date and calling remote (hosted) nodes leads to:

```x509: certificate signed by unknown authority```

### Solution

Download latest [ca-certificates](https://manpages.ubuntu.com/manpages/xenial/man8/update-ca-certificates.8.html) package and then run update.

### Open questions

None