### PR TITLE
Geth 1.10.3 fix - incorrect type for /accounts/balance response `graphQLBalance:Data.Block.Number` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,10 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 # Compile geth
 FROM golang-builder as geth-builder
 
-# VERSION: go-ethereum v.1.9.24
+# VERSION: go-ethereum v.1.10.3
 RUN git clone https://github.com/ethereum/go-ethereum \
   && cd go-ethereum \
-  && git checkout cc05b050df5f88e80bb26aaf6d2f339c49c2d702
+  && git checkout 991384a7f6719e1125ca0be7fb27d0c4d1c5d2d3
 
 RUN cd go-ethereum \
   && make geth

--- a/ethereum/client.go
+++ b/ethereum/client.go
@@ -1071,7 +1071,7 @@ type graphqlBalance struct {
 	Data struct {
 		Block struct {
 			Hash    string `json:"hash"`
-			Number  string `json:"number"`
+			Number  int64  `json:"number"`
 			Account struct {
 				Balance string `json:"balance"`
 				Nonce   string `json:"transactionCount"`
@@ -1127,10 +1127,6 @@ func (ec *Client) Balance(
 		return nil, errors.New(RosettaTypes.PrintStruct(bal.Errors))
 	}
 
-	blockIndex, ok := new(big.Int).SetString(bal.Data.Block.Number[2:], 16)
-	if !ok {
-		return nil, fmt.Errorf("could not extract block index from %s", bal.Data.Block.Number)
-	}
 	balance, ok := new(big.Int).SetString(bal.Data.Block.Account.Balance[2:], 16)
 	if !ok {
 		return nil, fmt.Errorf(
@@ -1155,7 +1151,7 @@ func (ec *Client) Balance(
 		},
 		BlockIdentifier: &RosettaTypes.BlockIdentifier{
 			Hash:  bal.Data.Block.Hash,
-			Index: blockIndex.Int64(),
+			Index: bal.Data.Block.Number,
 		},
 		Metadata: map[string]interface{}{
 			"nonce": nonce.Int64(),

--- a/ethereum/testdata/account_balance_0x4cfc400fed52f9681b42454c2db4b18ab98f8de1.json
+++ b/ethereum/testdata/account_balance_0x4cfc400fed52f9681b42454c2db4b18ab98f8de1.json
@@ -2,7 +2,7 @@
   "data": {
     "block": {
       "hash": "0x9999286598edf07606228ba0233736e544a086a8822c61f9db3706887fc25dda",
-      "number": "0x1fe5",
+      "number": 8165,
       "account": {
         "balance": "0x2324c0d180077fe7000",
         "transactionCount": "0x0",

--- a/ethereum/testdata/account_balance_invalid.json
+++ b/ethereum/testdata/account_balance_invalid.json
@@ -7,7 +7,7 @@
   "data": {
     "block": {
       "hash": "0x9b3483b52f88228eae8500cafdd61f129ed6803b7d4b37082af5ca1d299e8e04",
-      "number": "0x880fc5"
+      "number": 8916933
     }
   }
 }


### PR DESCRIPTION
Fixes #40 

### Motivation

`go-ethereum` `v1.10.x` introduces fixes to the `GraphQL` API. This creates a breaking change for `rosetta-ethereum`. 
This PR aims to address these issues.

### Solution

- Change type of `Data.Block.Number` in `graphqlBalance` into `int64` from `string`
- Don't try to parse the string - pass straight through `BlockIdentifier`

### Open questions

None at the moment