### PR TITLE
Fix: Copy & paste error on Rinkeby and Goerli network names

### DIFF
--- a/ethereum/types.go
+++ b/ethereum/types.go
@@ -40,11 +40,11 @@ const (
 
 	// RinkebyNetwork is the value of the network
 	// in RinkebyNetworkNetworkIdentifier.
-	RinkebyNetwork string = "RinkebyNetwork"
+	RinkebyNetwork string = "Rinkeby"
 
 	// GoerliNetwork is the value of the network
 	// in GoerliNetworkNetworkIdentifier.
-	GoerliNetwork string = "GoerliNetwork"
+	GoerliNetwork string = "Goerli"
 
 	// Symbol is the symbol value
 	// used in Currency.


### PR DESCRIPTION
Apologies, there was a copy & paste error on the network names in the previous PR. Should just be `Rinkeby` and `Goerli` not `RinkebyNetwork` and `GoerliNetwork` respectively. 