### PR TITLE
construction/payloads: Transaction input field should be data accordi…

### DIFF
--- a/services/construction_service.go
+++ b/services/construction_service.go
@@ -265,7 +265,7 @@ func (s *ConstructionAPIService) ConstructionPayloads(
 		From:     checkFrom,
 		To:       checkTo,
 		Value:    amount,
-		Input:    tx.Data(),
+		Data:     tx.Data(),
 		Nonce:    tx.Nonce(),
 		GasPrice: gasPrice,
 		GasLimit: tx.Gas(),
@@ -308,7 +308,7 @@ func (s *ConstructionAPIService) ConstructionCombine(
 		unsignedTx.Value,
 		unsignedTx.GasLimit,
 		unsignedTx.GasPrice,
-		unsignedTx.Input,
+		unsignedTx.Data,
 	)
 
 	signer := ethTypes.NewEIP155Signer(unsignedTx.ChainID)
@@ -366,7 +366,7 @@ func (s *ConstructionAPIService) ConstructionParse(
 
 		tx.To = t.To().String()
 		tx.Value = t.Value()
-		tx.Input = t.Data()
+		tx.Data = t.Data()
 		tx.Nonce = t.Nonce()
 		tx.GasPrice = t.GasPrice()
 		tx.GasLimit = t.Gas()

--- a/services/construction_service_test.go
+++ b/services/construction_service_test.go
@@ -141,7 +141,7 @@ func TestConstructionService(t *testing.T) {
 	}, metadataResponse)
 
 	// Test Payloads
-	unsignedRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","input":"0x","nonce":"0x0","gas_price":"0x3b9aca00","gas":"0x5208","chain_id":"0x3"}` // nolint
+	unsignedRaw := `{"from":"0xe3a5B4d7f79d64088C8d4ef153A7DDe2B2d47309","to":"0x57B414a0332B5CaB885a451c2a28a07d1e9b8a8d","value":"0x9864aac3510d02","data":"0x","nonce":"0x0","gas_price":"0x3b9aca00","gas":"0x5208","chain_id":"0x3"}` // nolint
 	payloadsResponse, err := servicer.ConstructionPayloads(ctx, &types.ConstructionPayloadsRequest{
 		NetworkIdentifier: networkIdentifier,
 		Operations:        ops,

--- a/services/types.go
+++ b/services/types.go
@@ -129,7 +129,7 @@ type transaction struct {
 	From     string   `json:"from"`
 	To       string   `json:"to"`
 	Value    *big.Int `json:"value"`
-	Input    []byte   `json:"input"`
+	Data     []byte   `json:"data"`
 	Nonce    uint64   `json:"nonce"`
 	GasPrice *big.Int `json:"gas_price"`
 	GasLimit uint64   `json:"gas"`
@@ -140,7 +140,7 @@ type transactionWire struct {
 	From     string `json:"from"`
 	To       string `json:"to"`
 	Value    string `json:"value"`
-	Input    string `json:"input"`
+	Data     string `json:"data"`
 	Nonce    string `json:"nonce"`
 	GasPrice string `json:"gas_price"`
 	GasLimit string `json:"gas"`
@@ -152,7 +152,7 @@ func (t *transaction) MarshalJSON() ([]byte, error) {
 		From:     t.From,
 		To:       t.To,
 		Value:    hexutil.EncodeBig(t.Value),
-		Input:    hexutil.Encode(t.Input),
+		Data:     hexutil.Encode(t.Data),
 		Nonce:    hexutil.EncodeUint64(t.Nonce),
 		GasPrice: hexutil.EncodeBig(t.GasPrice),
 		GasLimit: hexutil.EncodeUint64(t.GasLimit),
@@ -173,7 +173,7 @@ func (t *transaction) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	input, err := hexutil.Decode(tw.Input)
+	data_, err := hexutil.Decode(tw.Data)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (t *transaction) UnmarshalJSON(data []byte) error {
 	t.From = tw.From
 	t.To = tw.To
 	t.Value = value
-	t.Input = input
+	t.Data = data_
 	t.Nonce = nonce
 	t.GasPrice = gasPrice
 	t.GasLimit = gasLimit

--- a/services/types.go
+++ b/services/types.go
@@ -173,7 +173,7 @@ func (t *transaction) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	data_, err := hexutil.Decode(tw.Data)
+	twData, err := hexutil.Decode(tw.Data)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (t *transaction) UnmarshalJSON(data []byte) error {
 	t.From = tw.From
 	t.To = tw.To
 	t.Value = value
-	t.Data = data_
+	t.Data = twData
 	t.Nonce = nonce
 	t.GasPrice = gasPrice
 	t.GasLimit = gasLimit


### PR DESCRIPTION
Fixes #46

**Note:** This PR replaces #47. I deleted the fork and forgot about the link so had to re-instated.

### Motivation

When using the endpoint `construction/payloads` the `unsigned_transaction` payload is invalid for passing to a signer. Per #46 references it should be `data` when submitting to a signer and `input` is part of the response.

### Solution

Rename `input` to `data` on the `transaction` and `transactionWire` structs.

### Open questions

None