### PR TITLE
Revert "Add GETH_HEADERS to be set as a config environment variable (#44)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ at port `8080`.
 * `PORT`(required) - Which port to use for Rosetta.
 * `GETH` (optional) - Point to a remote `geth` node instead of initializing one
 * `SKIP_GETH_ADMIN` (optional, default: `FALSE`) - Instruct Rosetta to not use the `geth` `admin` RPC calls. This is typically disabled by hosted blockchain node services.
-* `GETH_HEADERS` (optional) - Pass a key:value comma-separated list to be passed to the `geth` clients. e.g. `X-Auth-Token:12345-ABCDE,X-Other-Header:SomeOtherValue`
 
 #### Mainnet:Online
 ```text

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,7 +92,7 @@ func runRunCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		var err error
-		client, err = ethereum.NewClient(cfg.GethURL, cfg.Params, cfg.SkipGethAdmin, cfg.GethHeaders)
+		client, err = ethereum.NewClient(cfg.GethURL, cfg.Params, cfg.SkipGethAdmin)
 		if err != nil {
 			return fmt.Errorf("%w: cannot initialize ethereum client", err)
 		}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/coinbase/rosetta-ethereum/ethereum"
 
@@ -87,11 +86,6 @@ const (
 	// by hosted node services. When not set, defaults to false.
 	SkipGethAdminEnv = "SKIP_GETH_ADMIN"
 
-	// GethHeadersEnv is an optional environment variable
-	// of a comma-separated list of key:value pairs to apply
-	// to geth clients as headers. When not set, defaults to []
-	GethHeadersEnv = "GETH_HEADERS"
-
 	// MiddlewareVersion is the version of rosetta-ethereum.
 	MiddlewareVersion = "0.0.4"
 )
@@ -106,7 +100,6 @@ type Configuration struct {
 	Port                   int
 	GethArguments          string
 	SkipGethAdmin          bool
-	GethHeaders            []*ethereum.HTTPHeader
 
 	// Block Reward Data
 	Params *params.ChainConfig
@@ -184,20 +177,6 @@ func LoadConfiguration() (*Configuration, error) {
 			return nil, fmt.Errorf("%w: unable to parse SKIP_GETH_ADMIN %s", err, envSkipGethAdmin)
 		}
 		config.SkipGethAdmin = val
-	}
-
-	envGethHeaders := os.Getenv(GethHeadersEnv)
-	if len(envGethHeaders) > 0 {
-		headers := strings.Split(envGethHeaders, ",")
-		headerKVs := make([]*ethereum.HTTPHeader, len(headers))
-		for i, pair := range headers {
-			kv := strings.Split(pair, ":")
-			headerKVs[i] = &ethereum.HTTPHeader{
-				Key:   kv[0],
-				Value: kv[1],
-			}
-		}
-		config.GethHeaders = headerKVs
 	}
 
 	portValue := os.Getenv(PortEnv)

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -33,7 +33,6 @@ func TestLoadConfiguration(t *testing.T) {
 		Port          string
 		Geth          string
 		SkipGethAdmin string
-		GethHeaders   string
 
 		cfg *Configuration
 		err error
@@ -55,7 +54,6 @@ func TestLoadConfiguration(t *testing.T) {
 			Network:       Mainnet,
 			Port:          "1000",
 			SkipGethAdmin: "FALSE",
-			GethHeaders:   "",
 			cfg: &Configuration{
 				Mode: Online,
 				Network: &types.NetworkIdentifier{
@@ -68,7 +66,6 @@ func TestLoadConfiguration(t *testing.T) {
 				GethURL:                DefaultGethURL,
 				GethArguments:          ethereum.MainnetGethArguments,
 				SkipGethAdmin:          false,
-				GethHeaders:            nil,
 			},
 		},
 		"all set (mainnet) + geth": {
@@ -77,7 +74,6 @@ func TestLoadConfiguration(t *testing.T) {
 			Port:          "1000",
 			Geth:          "http://blah",
 			SkipGethAdmin: "TRUE",
-			GethHeaders:   "X-Auth-Token:12345-ABCDE,X-Api-Version:2",
 			cfg: &Configuration{
 				Mode: Online,
 				Network: &types.NetworkIdentifier{
@@ -91,10 +87,6 @@ func TestLoadConfiguration(t *testing.T) {
 				RemoteGeth:             true,
 				GethArguments:          ethereum.MainnetGethArguments,
 				SkipGethAdmin:          true,
-				GethHeaders: []*ethereum.HTTPHeader{
-					{Key: "X-Auth-Token", Value: "12345-ABCDE"},
-					{Key: "X-Api-Version", Value: "2"},
-				},
 			},
 		},
 		"all set (ropsten)": {
@@ -112,7 +104,6 @@ func TestLoadConfiguration(t *testing.T) {
 				Port:                   1000,
 				GethURL:                DefaultGethURL,
 				GethArguments:          ethereum.RopstenGethArguments,
-				GethHeaders:            nil,
 			},
 		},
 		"all set (rinkeby)": {
@@ -130,7 +121,6 @@ func TestLoadConfiguration(t *testing.T) {
 				Port:                   1000,
 				GethURL:                DefaultGethURL,
 				GethArguments:          ethereum.RinkebyGethArguments,
-				GethHeaders:            nil,
 			},
 		},
 		"all set (goerli)": {
@@ -148,7 +138,6 @@ func TestLoadConfiguration(t *testing.T) {
 				Port:                   1000,
 				GethURL:                DefaultGethURL,
 				GethArguments:          ethereum.GoerliGethArguments,
-				GethHeaders:            nil,
 			},
 		},
 		"all set (testnet)": {
@@ -156,7 +145,6 @@ func TestLoadConfiguration(t *testing.T) {
 			Network:       Testnet,
 			Port:          "1000",
 			SkipGethAdmin: "TRUE",
-			GethHeaders:   "X-Auth-Token:12345-ABCDE,X-Api-Version:2",
 			cfg: &Configuration{
 				Mode: Online,
 				Network: &types.NetworkIdentifier{
@@ -169,10 +157,6 @@ func TestLoadConfiguration(t *testing.T) {
 				GethURL:                DefaultGethURL,
 				GethArguments:          ethereum.RopstenGethArguments,
 				SkipGethAdmin:          true,
-				GethHeaders: []*ethereum.HTTPHeader{
-					{Key: "X-Auth-Token", Value: "12345-ABCDE"},
-					{Key: "X-Api-Version", Value: "2"},
-				},
 			},
 		},
 		"invalid mode": {
@@ -202,7 +186,6 @@ func TestLoadConfiguration(t *testing.T) {
 			os.Setenv(PortEnv, test.Port)
 			os.Setenv(GethEnv, test.Geth)
 			os.Setenv(SkipGethAdminEnv, test.SkipGethAdmin)
-			os.Setenv(GethHeadersEnv, test.GethHeaders)
 
 			cfg, err := LoadConfiguration()
 			if test.err != nil {

--- a/ethereum/client.go
+++ b/ethereum/client.go
@@ -65,7 +65,7 @@ type Client struct {
 }
 
 // NewClient creates a Client that from the provided url and params.
-func NewClient(url string, params *params.ChainConfig, skipAdminCalls bool, headers []*HTTPHeader) (*Client, error) {
+func NewClient(url string, params *params.ChainConfig, skipAdminCalls bool) (*Client, error) {
 	c, err := rpc.DialHTTPWithClient(url, &http.Client{
 		Timeout: gethHTTPTimeout,
 	})
@@ -73,16 +73,12 @@ func NewClient(url string, params *params.ChainConfig, skipAdminCalls bool, head
 		return nil, fmt.Errorf("%w: unable to dial node", err)
 	}
 
-	for _, header := range headers {
-		c.SetHeader(header.Key, header.Value)
-	}
-
 	tc, err := loadTraceConfig()
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to load trace config", err)
 	}
 
-	g, err := newGraphQLClient(url, headers)
+	g, err := newGraphQLClient(url)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to create GraphQL client", err)
 	}

--- a/ethereum/graphql_client.go
+++ b/ethereum/graphql_client.go
@@ -35,9 +35,8 @@ const (
 // GraphQLClient is a client used to make graphQL
 // queries to geth's graphql endpoint.
 type GraphQLClient struct {
-	client  *http.Client
-	url     string
-	headers []*HTTPHeader
+	client *http.Client
+	url    string
 }
 
 // Query makes a query to the graphQL endpoint.
@@ -57,10 +56,6 @@ func (g *GraphQLClient) Query(ctx context.Context, input string) (string, error)
 		g.url,
 		bytes.NewBuffer(jsonValue),
 	)
-	for _, header := range g.headers {
-		request.Header.Set(header.Key, header.Value)
-	}
-
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +74,7 @@ func (g *GraphQLClient) Query(ctx context.Context, input string) (string, error)
 	return string(data), nil
 }
 
-func newGraphQLClient(baseURL string, headers []*HTTPHeader) (*GraphQLClient, error) {
+func newGraphQLClient(baseURL string) (*GraphQLClient, error) {
 	// Compute GraphQL Endpoint
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -102,8 +97,7 @@ func newGraphQLClient(baseURL string, headers []*HTTPHeader) (*GraphQLClient, er
 	client.Transport = customTransport
 
 	return &GraphQLClient{
-		client:  client,
-		url:     u.String(),
-		headers: headers,
+		client: client,
+		url:    u.String(),
 	}, nil
 }

--- a/ethereum/types.go
+++ b/ethereum/types.go
@@ -216,12 +216,6 @@ type GraphQL interface {
 	Query(ctx context.Context, input string) (string, error)
 }
 
-// HTTPHeader is key, value pair to be set on the HTTP and GraphQL client.
-type HTTPHeader struct {
-	Key   string
-	Value string
-}
-
 // CallType returns a boolean indicating
 // if the provided trace type is a call type.
 func CallType(t string) bool {


### PR DESCRIPTION
### Motivation

I originally added this because some hosted node providers were recommending in their docs to use an HTTP header to authenticate. However, the same providers in fact support the normal method via a URL query parameter.

These changes now feel unnecessary and this PR removes it to simplify the codebase.

### Solution

- This reverts commit 68306c7e2db84d1dd25210fbf2315fa579f49ea4. 
- Used `git revert <sha>` to generate.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
