### PR TITLE
feat(call): Add eth_getBlockByNumber support to /call endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ and run one of the following commands:
 ## Future Work
 * Add ERC-20 Rosetta Module to enable reading ERC-20 token transfers and transaction construction
 * [Rosetta API `/mempool/*`](https://www.rosetta-api.org/docs/MempoolApi.html) implementation
-* Add more methods to the `/call` endpoint (currently only support `eth_getTransactionReceipt`)
+* Add more methods to the `/call` endpoint (currently only supports `eth_getBlockByNumber` and `eth_getTransactionReceipt`)
 * Add CI test using `rosetta-cli` to run on each PR (likely on a regtest network)
 
 _Please reach out on our [community](https://community.rosetta-api.org) if you want to tackle anything on this list!_

--- a/ethereum/client_test.go
+++ b/ethereum/client_test.go
@@ -775,7 +775,6 @@ func TestCall_GetBlockByNumber(t *testing.T) {
 	c := &Client{
 		c:              mockJSONRPC,
 		g:              mockGraphQL,
-		p:              params.RopstenChainConfig,
 		traceSemaphore: semaphore.NewWeighted(100),
 	}
 

--- a/ethereum/client_test.go
+++ b/ethereum/client_test.go
@@ -768,7 +768,66 @@ func TestBalance_InvalidHash(t *testing.T) {
 	mockGraphQL.AssertExpectations(t)
 }
 
-func TestCall(t *testing.T) {
+func TestCall_GetBlockByNumber(t *testing.T) {
+	mockJSONRPC := &mocks.JSONRPC{}
+	mockGraphQL := &mocks.GraphQL{}
+
+	c := &Client{
+		c:              mockJSONRPC,
+		g:              mockGraphQL,
+		p:              params.RopstenChainConfig,
+		traceSemaphore: semaphore.NewWeighted(100),
+	}
+
+	ctx := context.Background()
+
+	mockJSONRPC.On(
+		"CallContext",
+		ctx,
+		mock.Anything,
+		"eth_getBlockByNumber",
+		"0x2af0",
+		false,
+	).Return(
+		nil,
+	).Run(
+		func(args mock.Arguments) {
+			r := args.Get(1).(*map[string]interface{})
+
+			file, err := ioutil.ReadFile("testdata/block_10992.json")
+			assert.NoError(t, err)
+
+			err = json.Unmarshal(file, r)
+			assert.NoError(t, err)
+		},
+	).Once()
+
+	correctRaw, err := ioutil.ReadFile("testdata/block_10992.json")
+	assert.NoError(t, err)
+	var correct map[string]interface{}
+	assert.NoError(t, json.Unmarshal(correctRaw, &correct))
+
+	resp, err := c.Call(
+		ctx,
+		&RosettaTypes.CallRequest{
+			Method: "eth_getBlockByNumber",
+			Parameters: map[string]interface{}{
+				"index":                    RosettaTypes.Int64(10992),
+				"show_transaction_details": false,
+			},
+		},
+	)
+	assert.Equal(t, &RosettaTypes.CallResponse{
+		Result:     correct,
+		Idempotent: false,
+	}, resp)
+	assert.NoError(t, err)
+
+	mockJSONRPC.AssertExpectations(t)
+	mockGraphQL.AssertExpectations(t)
+}
+
+func TestCall_GetTransactionReceipt(t *testing.T) {
 	mockJSONRPC := &mocks.JSONRPC{}
 	mockGraphQL := &mocks.GraphQL{}
 

--- a/ethereum/client_test.go
+++ b/ethereum/client_test.go
@@ -826,6 +826,34 @@ func TestCall_GetBlockByNumber(t *testing.T) {
 	mockGraphQL.AssertExpectations(t)
 }
 
+func TestCall_GetBlockByNumber_InvalidArgs(t *testing.T) {
+	mockJSONRPC := &mocks.JSONRPC{}
+	mockGraphQL := &mocks.GraphQL{}
+
+	c := &Client{
+		c:              mockJSONRPC,
+		g:              mockGraphQL,
+		traceSemaphore: semaphore.NewWeighted(100),
+	}
+
+	ctx := context.Background()
+	resp, err := c.Call(
+		ctx,
+		&RosettaTypes.CallRequest{
+			Method: "eth_getBlockByNumber",
+			Parameters: map[string]interface{}{
+				"index":                    "a string",
+				"show_transaction_details": false,
+			},
+		},
+	)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrCallParametersInvalid))
+
+	mockJSONRPC.AssertExpectations(t)
+	mockGraphQL.AssertExpectations(t)
+}
+
 func TestCall_GetTransactionReceipt(t *testing.T) {
 	mockJSONRPC := &mocks.JSONRPC{}
 	mockGraphQL := &mocks.GraphQL{}

--- a/ethereum/client_test.go
+++ b/ethereum/client_test.go
@@ -891,7 +891,7 @@ func TestCall_GetTransactionReceipt(t *testing.T) {
 	mockGraphQL.AssertExpectations(t)
 }
 
-func TestCall_InvalidArgs(t *testing.T) {
+func TestCall_GetTransactionReceipt_InvalidArgs(t *testing.T) {
 	mockJSONRPC := &mocks.JSONRPC{}
 	mockGraphQL := &mocks.GraphQL{}
 

--- a/ethereum/types.go
+++ b/ethereum/types.go
@@ -200,6 +200,7 @@ var (
 
 	// CallMethods are all supported call methods.
 	CallMethods = []string{
+		"eth_getBlockByNumber",
 		"eth_getTransactionReceipt",
 	}
 )


### PR DESCRIPTION
### Motivation

This PR adds support for `eth_getBlockByNumber` being called via the `/call` endpoint. 

### Solution

- Add `eth_getBlockByNumber` to `CallMethods` in `types.go`
- Add a `case` block for `eth_getBlockByNumber ` 

### Open questions

None