### PR TITLE
Fixed Call UnmarshalJSON bug

### DIFF
--- a/ethereum/client.go
+++ b/ethereum/client.go
@@ -697,7 +697,7 @@ func (t *Call) UnmarshalJSON(input []byte) error {
 		t.Value = new(big.Int)
 	}
 	if dec.GasUsed != nil {
-		t.GasUsed = (*big.Int)(dec.Value)
+		t.GasUsed = (*big.Int)(dec.GasUsed)
 	} else {
 		t.GasUsed = new(big.Int)
 	}


### PR DESCRIPTION
Fixes # .

### Motivation
I ported rosetta-ethereum project, and i found a bug when unmarshal Call object.

### Solution
Fixed `dec.Value` to `dec.GasUsed` to fill `t.GasUsed`

